### PR TITLE
reduce dependence on external libraries

### DIFF
--- a/core/src/main/java/com/moneydance/modules/features/importlist/io/FileAdmin.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/io/FileAdmin.java
@@ -42,7 +42,6 @@ import org.apache.commons.io.filefilter.IOFileFilter;
 import org.apache.commons.io.filefilter.SuffixFileFilter;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
-import org.apache.commons.lang3.SystemUtils;
 
 /**
  * This core class coordinates and delegates operations on the file system.

--- a/core/src/main/java/com/moneydance/modules/features/importlist/io/ImportOneOperation.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/io/ImportOneOperation.java
@@ -19,20 +19,18 @@ package com.moneydance.modules.features.importlist.io;
 import com.infinitekind.moneydance.model.Account;
 import com.infinitekind.moneydance.model.AccountUtil;
 import com.infinitekind.moneydance.model.AcctFilter;
+import com.infinitekind.util.StringUtils;
 import com.moneydance.apps.md.controller.FeatureModuleContext;
 import com.moneydance.modules.features.importlist.util.Helper;
 import com.moneydance.modules.features.importlist.util.Preferences;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.logging.Logger;
 
 import org.apache.commons.io.FilenameUtils;
-import org.apache.commons.lang3.text.StrSubstitutor;
 
 /**
  * @author Florian J. Breunig
@@ -68,24 +66,20 @@ final class ImportOneOperation implements FileOperation {
     @Override
     public void execute(final List<File> files) {
         final File file = files.iterator().next();
-        Map<String, String> valuesMap = new HashMap<String, String>(1);
-        valuesMap.put("filename",  file.getAbsolutePath());
-
+        
         String uriScheme = "";
         if (this.transactionFileFilter.accept(file)) {
-            uriScheme = Helper.INSTANCE.getSettings()
-                    .getTransactionFileImportUriScheme();
+          uriScheme = Helper.INSTANCE.getSettings().getTransactionFileImportUriScheme();
         } else if (this.textFileFilter.accept(file)) {
-            uriScheme = Helper.INSTANCE.getSettings()
-                    .getTextFileImportUriScheme();
-            valuesMap.put("accountno", this.getAccountNumberForFile(file));
+          uriScheme = Helper.INSTANCE.getSettings().getTextFileImportUriScheme();
+          uriScheme = StringUtils.replaceAll(uriScheme, "${accountno}", 
+                                             this.getAccountNumberForFile(file));
         }
-
-        final StrSubstitutor sub = new StrSubstitutor(valuesMap);
-        final String resolvedUri = sub.replace(uriScheme);
-
+        uriScheme = StringUtils.replaceAll(uriScheme, "${filename}", 
+                                           file.getAbsolutePath());
+        
         // Import the file by calling the URI
-        this.context.showURL(resolvedUri);
+        this.context.showURL(uriScheme);
     }
 
     private String getAccountNumberForFile(final File argFile) {

--- a/core/src/main/java/com/moneydance/modules/features/importlist/util/Helper.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/util/Helper.java
@@ -24,8 +24,6 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.logging.LogManager;
 
-import org.apache.commons.lang3.Validate;
-
 import javax.annotation.Nullable;
 
 /**
@@ -123,7 +121,9 @@ public enum Helper {
             final String resource) {
         ClassLoader cloader     = Helper.class.getClassLoader();
         InputStream inputStream = cloader.getResourceAsStream(resource);
-        Validate.notNull(inputStream, "Resource %s was not found.", resource);
+        if(inputStream==null) {
+          throw new NullPointerException("Resource "+resource+" was not found.");
+        }
         return inputStream;
     }
 

--- a/core/src/main/java/com/moneydance/modules/features/importlist/util/Tracker.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/util/Tracker.java
@@ -19,11 +19,10 @@ package com.moneydance.modules.features.importlist.util;
 import com.brsanthu.googleanalytics.EventHit;
 import com.brsanthu.googleanalytics.GoogleAnalytics;
 import com.brsanthu.googleanalytics.GoogleAnalyticsConfig;
+import com.infinitekind.util.StringUtils;
 
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * A facade for dispatching Google Analytics tracking information.
@@ -45,7 +44,7 @@ public final class Tracker {
         this.build = String.format("%s v%d", argExtensionName, argBuild);
 
         Settings settings = Helper.INSTANCE.getSettings();
-        boolean enabled = StringUtils.isNotEmpty(settings.getTrackingCode());
+        boolean enabled = ! StringUtils.isBlank(settings.getTrackingCode());
 
         GoogleAnalyticsConfig config = new GoogleAnalyticsConfig();
         config.setEnabled(enabled);

--- a/support/src/main/java/com/moneydance/apps/md/controller/StubContextFactory.java
+++ b/support/src/main/java/com/moneydance/apps/md/controller/StubContextFactory.java
@@ -25,8 +25,6 @@ import com.moneydance.util.StreamTable;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import org.apache.commons.lang3.Validate;
-
 import javax.annotation.Nullable;
 
 /**
@@ -50,7 +48,7 @@ public final class StubContextFactory {
     }
 
     public StubContextFactory(final FeatureModule argFeatureModule) {
-        Validate.notNull(argFeatureModule, "featureModule must not be null");
+        if(argFeatureModule==null) throw new NullPointerException("featureModule must not be null");
         this.featureModule  = argFeatureModule;
         this.context = new StubContext(this.featureModule);
         initContext(this.context);


### PR DESCRIPTION
This shouldn't change anything functionally, but I believe it simplifies things just a bit by reducing the dependency on external libraries from which only one or two methods are used.  Please feel free to reject this as unnecessary, especially since those dependencies can't actually be removed due to the tracking code.