### PR TITLE
import csv files directly

### DIFF
--- a/core/src/main/java/com/moneydance/modules/features/importlist/io/FileAdmin.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/io/FileAdmin.java
@@ -61,7 +61,6 @@ public final class FileAdmin extends Observable implements Observer {
     private final AbstractDirectoryChooser directoryChooser;
     private final DirectoryValidator directoryValidator;
     private final IOFileFilter transactionFileFilter;
-    private final IOFileFilter textFileFilter;
     private final IOFileFilter readableFileFilter;
     private final TransactionFileListener listener;
     private final FileAlterationMonitor monitor;
@@ -79,14 +78,9 @@ public final class FileAdmin extends Observable implements Observer {
         this.transactionFileFilter = new SuffixFileFilter(
                 Helper.INSTANCE.getSettings().getTransactionFileExtensions(),
                 IOCase.INSENSITIVE);
-        this.textFileFilter = new SuffixFileFilter(
-                Helper.INSTANCE.getSettings().getTextFileExtensions(),
-                IOCase.INSENSITIVE);
         this.readableFileFilter = FileFilterUtils.and(
                 CanReadFileFilter.CAN_READ,
-                FileFilterUtils.or(
-                        this.transactionFileFilter,
-                        this.textFileFilter));
+                this.transactionFileFilter);
 
         this.listener = new TransactionFileListener();
         this.listener.addObserver(this);
@@ -213,8 +207,7 @@ public final class FileAdmin extends Observable implements Observer {
     public void importAllRows() {
         FileOperation importAllOperation = new ImportAllOperation(
                 this.context,
-                this.transactionFileFilter,
-                this.textFileFilter);
+                this.transactionFileFilter);
         importAllOperation.showWarningAndExecute(this.files);
         this.setChanged();
         this.notifyObservers();
@@ -226,8 +219,7 @@ public final class FileAdmin extends Observable implements Observer {
         }
         FileOperation importOneOperation = new ImportOneOperation(
                 this.context,
-                this.transactionFileFilter,
-                this.textFileFilter);
+                this.transactionFileFilter);
         importOneOperation.showWarningAndExecute(
                 Collections.singletonList(this.files.get(rowNumber)));
         this.setChanged();

--- a/core/src/main/java/com/moneydance/modules/features/importlist/io/ImportAllOperation.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/io/ImportAllOperation.java
@@ -30,15 +30,12 @@ final class ImportAllOperation implements FileOperation {
 
     private final FeatureModuleContext context;
     private final FileFilter           transactionFileFilter;
-    private final FileFilter           textFileFilter;
 
     ImportAllOperation(
             final FeatureModuleContext argContext,
-            final FileFilter argTransactionFileFilter,
-            final FileFilter argTextFileFilter) {
+            final FileFilter argTransactionFileFilter) {
         this.context                = argContext;
         this.transactionFileFilter  = argTransactionFileFilter;
-        this.textFileFilter         = argTextFileFilter;
     }
 
     @Override
@@ -50,8 +47,7 @@ final class ImportAllOperation implements FileOperation {
     public void execute(final List<File> files) {
         FileOperation importOneOperation = new ImportOneOperation(
                 this.context,
-                this.transactionFileFilter,
-                this.textFileFilter);
+                this.transactionFileFilter);
         for (final File file : files) {
             importOneOperation.execute(Collections.singletonList(file));
         }

--- a/core/src/main/java/com/moneydance/modules/features/importlist/util/Settings.java
+++ b/core/src/main/java/com/moneydance/modules/features/importlist/util/Settings.java
@@ -139,17 +139,6 @@ public final class Settings {
     }
 
     /**
-     * @return Valid extensions of text files that can be imported
-     * (case-insensitive).
-     */
-    public String[] getTextFileExtensions() {
-        String[] textFileExtensions =
-                this.config.getStringArray(
-                        "text_file_extensions"); //$NON-NLS-1$
-        return textFileExtensions;
-    }
-
-    /**
      * @return Maximum length of a filename displayed in an error message.
      */
     public int getMaxFilenameLength() {

--- a/core/src/main/resources/settings.properties
+++ b/core/src/main/resources/settings.properties
@@ -44,10 +44,7 @@ text_file_import_uri_scheme = moneydance:fmodule:txtimport:?file=${filename}&acc
 monitor_interval = 10000
 
 # Valid extensions of transaction files that can be imported (case-insensitive).
-transaction_file_extensions = qif, ofx, qfx, ofc
-
-# Valid extensions of text files that can be imported (case-insensitive).
-text_file_extensions = csv
+transaction_file_extensions = qif, ofx, qfx, ofc, csv
 
 # Maximum length of a filename displayed in an error message.
 max_filename_length = 20

--- a/support/src/test/java/com/moneydance/modules/features/importlist/io/ImportAllOperationTest.java
+++ b/support/src/test/java/com/moneydance/modules/features/importlist/io/ImportAllOperationTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.filefilter.FalseFileFilter;
 import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,8 +47,7 @@ public final class ImportAllOperationTest {
 
         this.fileOperation = new ImportAllOperation(
                 context,
-                TrueFileFilter.TRUE,
-                FalseFileFilter.FALSE);
+                TrueFileFilter.TRUE);
     }
 
     @Test

--- a/support/src/test/java/com/moneydance/modules/features/importlist/io/ImportOneOperationTest.java
+++ b/support/src/test/java/com/moneydance/modules/features/importlist/io/ImportOneOperationTest.java
@@ -36,14 +36,10 @@ import org.junit.Test;
 public final class ImportOneOperationTest {
 
     private final File incomeFile;
-    private final File creditcardFile;
-    private final File noCategoryFile;
 
     public ImportOneOperationTest() {
         Helper.INSTANCE.getPreferences();
-        this.incomeFile     = new File("mybank.csv");
-        this.creditcardFile = new File("credit.csv");
-        this.noCategoryFile = new File("nocategory.csv");
+        this.incomeFile = new File("mybank.csv");
     }
 
     @Test
@@ -63,56 +59,12 @@ public final class ImportOneOperationTest {
         context.setAccountBook(accountBook);
         fileOperation = new ImportOneOperation(
                 context,
-                TrueFileFilter.TRUE,
-                FalseFileFilter.FALSE);
-        fileOperation.execute(Collections.singletonList(this.incomeFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                TrueFileFilter.TRUE,
-                FalseFileFilter.FALSE);
-        fileOperation.execute(Collections.singletonList(this.creditcardFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                TrueFileFilter.TRUE,
-                FalseFileFilter.FALSE);
-        fileOperation.execute(Collections.singletonList(this.noCategoryFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                FalseFileFilter.FALSE,
                 TrueFileFilter.TRUE);
         fileOperation.execute(Collections.singletonList(this.incomeFile));
 
         fileOperation = new ImportOneOperation(
                 context,
-                FalseFileFilter.FALSE,
-                TrueFileFilter.TRUE);
-        fileOperation.execute(Collections.singletonList(this.creditcardFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                FalseFileFilter.FALSE,
-                TrueFileFilter.TRUE);
-        fileOperation.execute(Collections.singletonList(this.noCategoryFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                FalseFileFilter.FALSE,
                 FalseFileFilter.FALSE);
         fileOperation.execute(Collections.singletonList(this.incomeFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                FalseFileFilter.FALSE,
-                FalseFileFilter.FALSE);
-        fileOperation.execute(Collections.singletonList(this.creditcardFile));
-
-        fileOperation = new ImportOneOperation(
-                context,
-                FalseFileFilter.FALSE,
-                FalseFileFilter.FALSE);
-        fileOperation.execute(Collections.singletonList(this.noCategoryFile));
     }
 }

--- a/support/src/test/java/com/moneydance/modules/features/importlist/util/SettingsTest.java
+++ b/support/src/test/java/com/moneydance/modules/features/importlist/util/SettingsTest.java
@@ -83,11 +83,6 @@ public final class SettingsTest {
     }
 
     @Test
-    public void testGetTextFileExtensions() {
-        assertThat(this.settings.getTextFileExtensions(), notNullValue());
-    }
-
-    @Test
     public void testGetMaxFilenameLength() {
         assertThat(this.settings.getMaxFilenameLength(), notNullValue());
     }


### PR DESCRIPTION
this is a tiny change that includes csv as one of the extensions for files that can be imported using the built-in import mechanism in Moneydance rather than invoking another extension.