### PR TITLE
Upgrade Java target from 11 to 21

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v6
     - uses: actions/setup-java@v5
       with:
-        java-version: '17'
+        java-version: '21'
         distribution: 'temurin'
     - uses: gradle/actions/wrapper-validation@v6
     - uses: gradle/actions/setup-gradle@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Run static analysis: `./gradlew pmdMain`
 
 ## Code Style Guidelines
-- Java 11 compatibility (release = 11)
+- Java 21 compatibility (release = 21)
 - Line length: max 120 characters
 - Use explicit imports (no star imports)
 - Import order: com.*, java.*, javax.*, other

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ to install the extension please visit the
 [project page](https://www.my-flow.com/importlist/).
 
 ## Build Prerequisites
-* Java Development Kit, version 17
+* Java Development Kit, version 21
 
 ## Building the extension
 1. `git clone git@github.com:my-flow/importlist.git` creates a copy of the

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
     apply plugin: 'org.sonarqube'
 
     tasks.withType(JavaCompile) {
-        options.release = 11
+        options.release = 21
     }
 
     ext {

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ dependencies {
     api('commons-io:commons-io:2.21.0')
     api('org.slf4j:slf4j-api:2.0.17')
     api('org.slf4j:slf4j-nop:2.0.17')
-    api('org.checkerframework:checker:3.51.1')
+    api('org.checkerframework:checker:3.54.0')
     api('com.github.spotbugs:spotbugs:4.9.8')
 
     spotbugsPlugins 'com.mebigfatguy.sb-contrib:sb-contrib:7.7.4'
@@ -22,7 +22,7 @@ javadoc {
     options.docTitle = 'Import List for Moneydance'
     options.windowTitle = 'Import List for Moneydance'
     options.links = [
-        'https://docs.oracle.com/en/java/javase/17/docs/api/',
+        'https://docs.oracle.com/en/java/javase/21/docs/api/',
         'https://infinitekind.com/dev/apidoc/',
         'https://www.slf4j.org/apidocs/',
         'https://commons.apache.org/proper/commons-configuration/apidocs/',


### PR DESCRIPTION
## Summary
- Raise the project compilation target from Java 11 to Java 21
- Update CI workflow to use JDK 21
- Bump `org.checkerframework:checker` from 3.51.1 to 3.54.0 (requires JVM 21+)
- Update Javadoc link to Java 21 API docs
- Update README and CLAUDE.md to reflect the new Java version

## Context
Checker framework 3.52.0+ requires JVM 21. This change unblocks PR #151 and all future checker framework updates.

## Test plan
- [x] CI build passes with JDK 21
- [x] All existing tests pass
- [x] Checkstyle, PMD, and SpotBugs checks pass