### PR TITLE
Configure Dependabot target branch and PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,9 +2,13 @@ version: 2
 updates:
   - package-ecosystem: "gradle"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "develop"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
- Set explicit `target-branch: develop` for both Gradle and GitHub Actions ecosystems
- Add `open-pull-requests-limit: 5` to prevent stale PRs from accumulating

This addresses the issue seen in PR #98, where a Dependabot PR for `sonarqube-gradle-plugin` 6.3.0 remained open despite `develop` already having version 7.2.3.

## Test plan
- [ ] Verify Dependabot creates new PRs targeting `develop`
- [ ] Verify no more than 5 open Dependabot PRs exist per ecosystem

🤖 Generated with [Claude Code](https://claude.com/claude-code)